### PR TITLE
update total staked when burning shares

### DIFF
--- a/near-staker/src/internal.rs
+++ b/near-staker/src/internal.rs
@@ -138,8 +138,10 @@ impl NearStaker {
             return Promise::new(caller).transfer(attached_near);
         }
 
-        // burn user shares
+        // burn user shares and update total staked to keep share price the same
         self.internal_burn(shares_amount, caller.clone());
+        self.total_staked -= amount;
+        self.tax_exempt_stake = self.tax_exempt_stake.saturating_sub(amount);
 
         // prepare unstake arguments
         let unstake_amount = json!({ "amount": NearToken::from_yoctonear(amount) })

--- a/near-staker/src/lib.rs
+++ b/near-staker/src/lib.rs
@@ -1116,6 +1116,8 @@ impl NearStaker {
             Err(_) => {
                 log!("Failed to unstake: {}", ERR_CALLBACK_FAILED);
                 self.internal_mint(shares_amount.0, caller.clone());
+                self.total_staked += amount.0;
+                self.tax_exempt_stake += amount.0;
                 Promise::new(caller).transfer(attached_near);
                 return;
             }
@@ -1135,8 +1137,6 @@ impl NearStaker {
         // update delegation pool and total_staked
         pool.last_unstake = Some(env::epoch_height());
         pool.total_staked = (pool.total_staked.0 - amount.0).into();
-        self.total_staked -= amount.0;
-        self.tax_exempt_stake = self.tax_exempt_stake.saturating_sub(amount.0);
         log!("Updated total_staked: {}", self.total_staked);
 
         log!(


### PR DESCRIPTION
This fix ensures that the share price does not increases between the initial unstake request (where user shares are burned) and the unstake callback (where total staked is updated).

We should really always update the contract total staked amount in the same transaction where shares are minted/burned.