### PR TITLE
add ft_price function and corresponding tests for TruNEAR share price

### DIFF
--- a/near-staker/src/lib.rs
+++ b/near-staker/src/lib.rs
@@ -346,6 +346,17 @@ impl NearStaker {
         (num.to_string(), denom.to_string())
     }
 
+    /// Returns the current TruNEAR share price in NEAR as a 24 decimal number.
+    pub fn ft_price(&self) -> U128 {
+        let (num, denom) = Self::internal_share_price(
+            self.total_staked,
+            self.token.ft_total_supply().0,
+            self.tax_exempt_stake,
+            self.fee,
+        );
+        U128(u128::try_from(num / denom).unwrap())
+    }
+
     /// Returns the maximum amount of NEAR a user can withdraw from the vault, rounding the result up.
     pub fn max_withdraw(&self, account_id: AccountId) -> U128 {
         let (share_price_num, share_price_denom) = Self::internal_share_price(

--- a/near-staker/tests/helpers.rs
+++ b/near-staker/tests/helpers.rs
@@ -435,6 +435,17 @@ pub async fn get_share_price(contract: Contract) -> Result<u128, Box<dyn std::er
     Ok(share_price)
 }
 
+pub async fn get_ft_price(contract: Contract) -> Result<U128, Box<dyn std::error::Error>> {
+    let response = contract
+        .view("ft_price")
+        .args_json(json!({}))
+        .await?
+        .json::<U128>()
+        .unwrap();
+
+    Ok(response)
+}
+
 pub async fn share_price_fraction(
     contract: &Contract,
 ) -> Result<(U256, U256), Box<dyn std::error::Error>> {

--- a/near-staker/tests/test_views.rs
+++ b/near-staker/tests/test_views.rs
@@ -50,6 +50,61 @@ async fn test_share_price_increases_with_rewards() -> Result<(), Box<dyn std::er
 }
 
 #[tokio::test]
+async fn test_ft_price_initial_value() -> Result<(), Box<dyn std::error::Error>> {
+    let (_, _, contract) = setup_contract().await?;
+
+    let ft_price = contract
+        .view("ft_price")
+        .args_json(json!({}))
+        .await?
+        .json::<U128>()
+        .unwrap();
+
+    assert_eq!(ft_price.0, SHARE_PRICE_SCALING_FACTOR);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_ft_price_increases_with_rewards_and_stake() -> Result<(), Box<dyn std::error::Error>>
+{
+    let (owner, sandbox, contract, _) = setup_contract_with_pool().await?;
+    let alice = owner
+        .create_subaccount("alice")
+        .initial_balance(NearToken::from_near(100000000))
+        .transact()
+        .await?
+        .unwrap();
+
+    let _ = owner
+        .call(contract.id(), "add_user_to_whitelist")
+        .args_json(json!({
+            "user_id": alice.id(),
+        }))
+        .transact()
+        .await?;
+
+    let _ = stake(&contract, alice.clone(), 10000000).await?;
+    let ft_price_first_epoch = get_ft_price(contract.clone()).await?;
+    let share_price_first_epoch = get_share_price(contract.clone()).await?;
+    assert_eq!(ft_price_first_epoch.0, share_price_first_epoch);
+
+    move_epoch_forward_and_update_total_staked(&sandbox, &contract, owner.clone()).await?;
+    let ft_price_second_epoch = get_ft_price(contract.clone()).await?;
+    let share_price_second_epoch = get_share_price(contract.clone()).await?;
+    assert_eq!(ft_price_second_epoch.0, share_price_second_epoch);
+    assert!(ft_price_second_epoch > ft_price_first_epoch);
+
+    move_epoch_forward_and_update_total_staked(&sandbox, &contract, owner.clone()).await?;
+    let ft_price_third_epoch = get_ft_price(contract.clone()).await?;
+    let share_price_third_epoch = get_share_price(contract.clone()).await?;
+    assert_eq!(ft_price_third_epoch.0, share_price_third_epoch);
+    assert!(ft_price_third_epoch > ft_price_second_epoch);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_max_withdraw_initial_value() -> Result<(), Box<dyn std::error::Error>> {
     let (_, _, contract) = setup_contract().await?;
     let alice = accounts(0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to view the current TruNEAR share price denominated in NEAR.
- **Tests**
	- Added tests to verify the initial value and behaviour of the new share price method, including its increase with rewards and staking over epochs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->